### PR TITLE
feat : Carousel 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cors": "^2.8.5",
+    "embla-carousel-react": "^8.3.0",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.436.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      embla-carousel-react:
+        specifier: ^8.3.0
+        version: 8.3.0(react@18.0.0)
       express:
         specifier: ^4.19.2
         version: 4.21.1
@@ -3290,6 +3293,19 @@ packages:
 
   elliptic@6.5.7:
     resolution: {integrity: sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==}
+
+  embla-carousel-react@8.3.0:
+    resolution: {integrity: sha512-P1FlinFDcIvggcErRjNuVqnUR8anyo8vLMIH8Rthgofw7Nj8qTguCa2QjFAbzxAUTQTPNNjNL7yt0BGGinVdFw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0
+
+  embla-carousel-reactive-utils@8.3.0:
+    resolution: {integrity: sha512-EYdhhJ302SC4Lmkx8GRsp0sjUhEN4WyFXPOk0kGu9OXZSRMmcBlRgTvHcq8eKJE1bXWBsOi1T83B+BSSVZSmwQ==}
+    peerDependencies:
+      embla-carousel: 8.3.0
+
+  embla-carousel@8.3.0:
+    resolution: {integrity: sha512-Ve8dhI4w28qBqR8J+aMtv7rLK89r1ZA5HocwFz6uMB/i5EiC7bGI7y+AM80yAVUJw3qqaZYK7clmZMUR8kM3UA==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -9748,6 +9764,18 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  embla-carousel-react@8.3.0(react@18.0.0):
+    dependencies:
+      embla-carousel: 8.3.0
+      embla-carousel-reactive-utils: 8.3.0(embla-carousel@8.3.0)
+      react: 18.0.0
+
+  embla-carousel-reactive-utils@8.3.0(embla-carousel@8.3.0):
+    dependencies:
+      embla-carousel: 8.3.0
+
+  embla-carousel@8.3.0: {}
 
   emittery@0.13.1: {}
 

--- a/src/_common/_components/Carousel/Shadcn_Carousel.tsx
+++ b/src/_common/_components/Carousel/Shadcn_Carousel.tsx
@@ -1,0 +1,260 @@
+"use client"
+
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y"
+      },
+      plugins
+    )
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+    const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return
+      }
+
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }, [])
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev()
+    }, [api])
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext()
+    }, [api])
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault()
+          scrollPrev()
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault()
+          scrollNext()
+        }
+      },
+      [scrollPrev, scrollNext]
+    )
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return
+      }
+
+      setApi(api)
+    }, [api, setApi])
+
+    React.useEffect(() => {
+      if (!api) {
+        return
+      }
+
+      onSelect(api)
+      api.on("reInit", onSelect)
+      api.on("select", onSelect)
+
+      return () => {
+        api?.off("select", onSelect)
+      }
+    }, [api, onSelect])
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext
+        }}>
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}>
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    )
+  }
+)
+Carousel.displayName = "Carousel"
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div
+      ref={carouselRef}
+      className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+CarouselContent.displayName = "CarouselContent"
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+CarouselItem.displayName = "CarouselItem"
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}>
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+})
+CarouselPrevious.displayName = "CarouselPrevious"
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}>
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+})
+CarouselNext.displayName = "CarouselNext"
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext
+}

--- a/src/_common/_components/Carousel/index.tsx
+++ b/src/_common/_components/Carousel/index.tsx
@@ -11,7 +11,6 @@ import {
 
 type CarouselProps = {
   children: React.ReactNode
-  showArrows?: boolean
   autoPlay?: boolean
   interval?: number
   showNavBar?: boolean

--- a/src/_common/_components/Carousel/index.tsx
+++ b/src/_common/_components/Carousel/index.tsx
@@ -66,7 +66,7 @@ const Carousel = ({
       {showNavBar && (
         <div
           className={cn(
-            "absolute left-0 right-0 flex justify-center gap-2",
+            "mt-1 absolute left-0 right-0 flex justify-center gap-2",
             navBarClassName
           )}>
           {[...Array(count)].map((_, index) => (

--- a/src/_common/_components/Carousel/index.tsx
+++ b/src/_common/_components/Carousel/index.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { cn } from "@/lib/utils"
+import {
+  Carousel as ShadcnCarousel,
+  CarouselContent,
+  CarouselItem,
+  type CarouselApi
+} from "@/_common/_components/Carousel/Shadcn_Carousel"
+
+type CarouselProps = {
+  children: React.ReactNode
+  showArrows?: boolean
+  autoPlay?: boolean
+  interval?: number
+  showNavBar?: boolean
+  navBarClassName?: string
+  className?: string
+}
+
+const Carousel = ({
+  children,
+  autoPlay = false,
+  showNavBar = false,
+  interval = 3000,
+  navBarClassName,
+  className
+}: CarouselProps) => {
+  const [api, setApi] = useState<CarouselApi>()
+  const [current, setCurrent] = useState(0)
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    if (!api) return
+
+    setCount(api.scrollSnapList().length)
+    setCurrent(api.selectedScrollSnap())
+
+    api.on("select", () => {
+      setCurrent(api.selectedScrollSnap())
+    })
+  }, [api])
+
+  useEffect(() => {
+    if (api && autoPlay) {
+      const autoPlayInterval = setInterval(() => {
+        api.scrollNext()
+      }, interval)
+
+      return () => clearInterval(autoPlayInterval)
+    }
+  }, [api, autoPlay, interval])
+
+  return (
+    <div className={`relative ${className}`}>
+      <ShadcnCarousel
+        setApi={setApi}
+        className="w-full"
+        opts={{
+          align: "start",
+          loop: true
+        }}>
+        <CarouselContent>{children}</CarouselContent>
+      </ShadcnCarousel>
+      {showNavBar && (
+        <div
+          className={cn(
+            "absolute left-0 right-0 flex justify-center gap-2",
+            navBarClassName
+          )}>
+          {[...Array(count)].map((_, index) => (
+            <button
+              key={index}
+              className={`h-2 w-2 rounded-full transition-all bg-black dark:bg-white${
+                index === current ? " w-4" : ""
+              }`}
+              onClick={() => api?.scrollTo(index)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const CarouselSlide = ({
+  children,
+  className
+}: React.PropsWithChildren<{ className?: string }>) => {
+  return <CarouselItem className={className}>{children}</CarouselItem>
+}
+
+Carousel.Slide = CarouselSlide
+
+export default Carousel

--- a/src/_common/_components/temp.tsx
+++ b/src/_common/_components/temp.tsx
@@ -1,9 +1,0 @@
-import { useEffect } from "react"
-import CustomError from "@/lib/CustomError"
-
-export default function Temp() {
-  useEffect(() => {
-    throw new CustomError("페이지를 발견할 수 없습니다", 400)
-  }, [])
-  return <div></div>
-}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,5 @@
 "use client"
 
-import Carousel from "@/_common/_components/Carousel"
-
 export default function Home() {
-  return (
-    <div>
-      <Carousel
-        autoPlay
-        className="w-full max-w-xs">
-        <Carousel.Slide>
-          <p>Slide 1</p>
-        </Carousel.Slide>
-        <Carousel.Slide>
-          <p>Slide 2</p>
-        </Carousel.Slide>
-        <Carousel.Slide>
-          <p>Slide 3</p>
-        </Carousel.Slide>
-      </Carousel>
-    </div>
-  )
+  return <div></div>
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,23 @@
 "use client"
 
-import ErrorBoundary from "@/_common/_components/ErrorBoundary"
-import Temp from "@/_common/_components/temp"
+import Carousel from "@/_common/_components/Carousel"
+
 export default function Home() {
   return (
     <div>
-      <ErrorBoundary>
-        <Temp />
-        <p>안녕</p>
-      </ErrorBoundary>
+      <Carousel
+        autoPlay
+        className="w-full max-w-xs">
+        <Carousel.Slide>
+          <p>Slide 1</p>
+        </Carousel.Slide>
+        <Carousel.Slide>
+          <p>Slide 2</p>
+        </Carousel.Slide>
+        <Carousel.Slide>
+          <p>Slide 3</p>
+        </Carousel.Slide>
+      </Carousel>
     </div>
   )
 }

--- a/src/stories/Carousel.stories.tsx
+++ b/src/stories/Carousel.stories.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { Meta, StoryFn } from "@storybook/react"
+import Carousel from "@/_common/_components/Carousel"
+
+export default {
+  title: "component/Carousel",
+  component: Carousel,
+  argTypes: {
+    autoPlay: { control: "boolean", description: "자동 재생 여부" },
+    interval: { control: "number", description: "자동 재생 간격 (ms)" },
+    showNavBar: { control: "boolean", description: "네비게이션 바 표시 여부" },
+    navBarClassName: {
+      control: "text",
+      description: "네비게이션 바 추가 클래스"
+    },
+    className: { control: "text", description: "캐러셀 컨테이너 추가 클래스" }
+  }
+} as Meta<typeof Carousel>
+
+const Template: StoryFn<typeof Carousel> = (args) => (
+  <Carousel {...args}>
+    <Carousel.Slide>
+      <div className="h-64 bg-red-500 flex items-center justify-center text-white text-2xl">
+        슬라이드 1
+      </div>
+    </Carousel.Slide>
+    <Carousel.Slide>
+      <div className="h-64 bg-blue-500 flex items-center justify-center text-white text-2xl">
+        슬라이드 2
+      </div>
+    </Carousel.Slide>
+    <Carousel.Slide>
+      <div className="h-64 bg-green-500 flex items-center justify-center text-white text-2xl">
+        슬라이드 3
+      </div>
+    </Carousel.Slide>
+  </Carousel>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  autoPlay: false,
+  interval: 3000,
+  showNavBar: true,
+  navBarClassName: "",
+  className: "max-w-md mx-auto"
+}
+
+export const AutoPlay = Template.bind({})
+AutoPlay.args = {
+  ...Default.args,
+  autoPlay: true
+}
+
+export const WithoutNavBar = Template.bind({})
+WithoutNavBar.args = {
+  ...Default.args,
+  showNavBar: false
+}


### PR DESCRIPTION
## Todos 
- [x] Carousel 컴포넌트 추가
  * Auto Slide 기능 구현 
  * 페이지 NavBar 구현 

<br/>

### Carousel 컴포넌트 추가
![2024-10-189 33 41-ezgif com-resize (1)](https://github.com/user-attachments/assets/dbc05b52-05e1-4875-a944-7f16e26cf479)
기존의 shadcn에서의 Carousel 컴포넌트를 구현했습니다 

### Props 
```javascript
type CarouselProps = {
  children: React.ReactNode
  autoPlay?: boolean     // 자동 슬라이드 on/off
  interval?: number // 자동 슬라이드 주기 
  showNavBar?: boolean  // 하단 슬라이드 nav 바 on/off
  navBarClassName?: string. // navBar 커스텀용 classname
  className?: string // Carosuel ClassName 
}
```

#### 사용 예시 
```
import Carousel from "@/_common/_components/Carousel"

export default function Home() {
  return (
    <div>
      <Carousel
        autoPlay
        className="w-full max-w-xs">
        <Carousel.Slide>
          <p>Slide 1</p>
        </Carousel.Slide>
        <Carousel.Slide>
          <p>Slide 2</p>
        </Carousel.Slide>
        <Carousel.Slide>
          <p>Slide 3</p>
        </Carousel.Slide>
      </Carousel>
    </div>
  ) 
```
## 관련 PR
close #104 