### PR TITLE
feat: 내 정보 조회, 프로필 입력, 사진 업로드 API 연결

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,14 @@ const nextConfig = {
   },
   images: {
     domains: ["placekitten.com", "picsum.photos", "source.unsplash.com"]
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/api/v1/:path*",
+        destination: `${process.env.NEXT_PUBLIC_APL_URL}/dev/api/v1/:path*`
+      }
+    ]
   }
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,7 @@ const nextConfig = {
     return [
       {
         source: "/api/v1/:path*",
-        destination: `${process.env.NEXT_PUBLIC_APL_URL}/dev/api/v1/:path*`
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/dev/api/v1/:path*`
       }
     ]
   }

--- a/src/app/kakao/_api/auth/csrf/index.ts
+++ b/src/app/kakao/_api/auth/csrf/index.ts
@@ -3,7 +3,7 @@ import { useMutation } from "@tanstack/react-query"
 
 export const postCSRF = async () => {
   try {
-    return fetch("/dev/api/v1/csrf", {
+    return http("/api/v1/csrf", {
       method: "POST",
       credentials: "include",
       headers: {

--- a/src/app/kakao/_components/AvatarForm.tsx
+++ b/src/app/kakao/_components/AvatarForm.tsx
@@ -5,18 +5,18 @@ import Button from "@/_common/_components/Button"
 
 import { useAvatarForm } from "../_hooks/_useAvatarForm"
 
-const AvatarForm = ({ onSubmit }: { onSubmit?: () => void }) => {
+const AvatarForm = ({
+  onSubmit
+}: {
+  onSubmit?: (profileimage: string) => void
+}) => {
   const { user, setUser } = useSignInContext()
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const { avatarSrc, handleFileChange } = useAvatarForm()
 
   const handleNextStep = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      profileImg: avatarSrc ?? ""
-    }))
-    if (onSubmit) onSubmit()
+    if (onSubmit && avatarSrc) onSubmit(avatarSrc)
   }
 
   return (
@@ -49,6 +49,7 @@ const AvatarForm = ({ onSubmit }: { onSubmit?: () => void }) => {
               사진 업로드
             </Button>
             <Button
+              type="button"
               onClick={handleNextStep}
               className="bg-black hover:bg-gray-800 text-white py-2 px-4 rounded-xl text-base font-medium transition duration-200">
               다음

--- a/src/app/kakao/_components/NickNameForm.tsx
+++ b/src/app/kakao/_components/NickNameForm.tsx
@@ -2,8 +2,12 @@ import Button from "@/_common/_components/Button"
 import Input from "@/_common/_components/Input"
 import { useSignInContext } from "@/app/kakao/_context/signinContext"
 
-const NickNameForm = ({ onSubmit }: { onSubmit?: () => void }) => {
-  const { setUser } = useSignInContext()
+const NickNameForm = ({
+  onSubmit
+}: {
+  onSubmit?: (nickname: string) => void
+}) => {
+  const { setUser, user } = useSignInContext()
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-white">
@@ -30,7 +34,12 @@ const NickNameForm = ({ onSubmit }: { onSubmit?: () => void }) => {
             className="border border-gray-300 rounded-xl p-4 w-full focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition duration-200"
           />
           <Button
-            onClick={onSubmit}
+            type="button"
+            onClick={() => {
+              if (user.nickName) {
+                onSubmit?.(user.nickName)
+              }
+            }}
             className="bg-blue-500 hover:bg-blue-600 text-white py-4 rounded-xl text-base font-medium transition duration-200">
             다음
           </Button>

--- a/src/app/kakao/_components/NickNameForm.tsx
+++ b/src/app/kakao/_components/NickNameForm.tsx
@@ -9,6 +9,20 @@ const NickNameForm = ({
 }) => {
   const { setUser, user } = useSignInContext()
 
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newNickName = e.target.value
+
+    if (newNickName.length <= 20) {
+      setUser({
+        nickName: newNickName,
+        social_id: "",
+        social_type: "KAKAO",
+        profileImg: "",
+        phone_number: ""
+      })
+    }
+  }
+
   return (
     <div className="flex items-center justify-center min-h-screen bg-white">
       <div className="w-full max-w-md text-center">
@@ -18,26 +32,23 @@ const NickNameForm = ({
         <p className="text-base text-gray-600 mb-6">
           다른 사람들에게 보여질 이름이에요
         </p>
-        <form className="flex flex-col space-y-4">
+        <form
+          className="flex flex-col space-y-4"
+          onSubmit={(e) => e.preventDefault()}>
           <Input
-            defaultValue={""}
-            onChange={(e) => {
-              setUser({
-                nickName: e.target.value,
-                social_id: "",
-                social_type: "KAKAO",
-                profileImg: "",
-                phone_number: ""
-              })
-            }}
-            placeholder="닉네임 (2~15자)"
+            defaultValue={user?.nickName}
+            value={user?.nickName}
+            onChange={handleInputChange}
+            placeholder="닉네임 (2~20자)"
             className="border border-gray-300 rounded-xl p-4 w-full focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition duration-200"
           />
           <Button
             type="button"
             onClick={() => {
-              if (user.nickName) {
+              if (user.nickName.length >= 2 && user.nickName.length <= 20) {
                 onSubmit?.(user.nickName)
+              } else {
+                alert("닉네임은 2자 이상 20자 이하로 입력해 주세요.")
               }
             }}
             className="bg-blue-500 hover:bg-blue-600 text-white py-4 rounded-xl text-base font-medium transition duration-200">

--- a/src/app/kakao/_hooks/_mutations/useKakaoMutation.ts
+++ b/src/app/kakao/_hooks/_mutations/useKakaoMutation.ts
@@ -7,7 +7,7 @@ interface KakaoOAuthLoginReq {
 
 export const kakaoOAuthLogin = async ({ code }: KakaoOAuthLoginReq) => {
   try {
-    const response = await fetch(`/dev/api/v1/login/oauth/kakao?code=${code}`, {
+    const response = await http(`/api/v1/login/oauth/kakao?code=${code}`, {
       method: "POST",
       credentials: "include",
       headers: {
@@ -16,8 +16,13 @@ export const kakaoOAuthLogin = async ({ code }: KakaoOAuthLoginReq) => {
       }
     })
 
-    return response
+    if (response.status === 200) {
+      return { data: "success" }
+    }
+
+    return response.data
   } catch (e) {
+    console.log(e)
     throw e
   }
 }

--- a/src/app/kakao/_hooks/_mutations/useUpdateNickname.ts
+++ b/src/app/kakao/_hooks/_mutations/useUpdateNickname.ts
@@ -1,0 +1,37 @@
+import { http } from "@/lib/http"
+import { useMutation } from "@tanstack/react-query"
+
+export const updateNickname = async ({ nickname }: { nickname: string }) => {
+  try {
+    const xsrfToken = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("XSRF-TOKEN="))
+      ?.split("=")[1]
+    const response = await http("/api/v1/users/profile/display-name", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "*",
+        "Access-Control-Allow-Origin": "*",
+        "X-XSRF-TOKEN": xsrfToken + ""
+      },
+      body: JSON.stringify({
+        display_name: nickname
+      })
+    })
+
+    if (response.status === 200) {
+      return { data: "success" }
+    }
+
+    return response
+  } catch (e) {
+    throw e
+  }
+}
+
+export const useUpdateNicknameMutation = () => {
+  return useMutation({
+    mutationFn: updateNickname
+  })
+}

--- a/src/app/kakao/_hooks/_mutations/useUpdateProfile.ts
+++ b/src/app/kakao/_hooks/_mutations/useUpdateProfile.ts
@@ -1,0 +1,37 @@
+import { http } from "@/lib/http"
+import { useMutation } from "@tanstack/react-query"
+
+export const updateProfileImage = async (image: string) => {
+  try {
+    const xsrfToken = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("XSRF-TOKEN="))
+      ?.split("=")[1]
+
+    const response = await http("/api/v1/users/profile/image", {
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "X-XSRF-TOKEN": xsrfToken || ""
+      },
+      body: JSON.stringify({
+        profile_image_url: image
+      })
+    })
+
+    if (response.status === 200) {
+      return { data: "success" }
+    }
+
+    return response
+  } catch (e) {
+    throw e
+  }
+}
+
+export const useUpdateProfileImageMutation = () => {
+  return useMutation({
+    mutationFn: updateProfileImage
+  })
+}

--- a/src/app/kakao/login/[socialid]/page.tsx
+++ b/src/app/kakao/login/[socialid]/page.tsx
@@ -8,11 +8,12 @@ import { SuccessLogin } from "@/app/kakao/_components/SuccessLogin"
 import { useToast } from "@/_common/_hooks/useToast"
 import { useRouter } from "next/navigation"
 import { useGetCSRFToken } from "@/app/kakao/_api/auth/csrf"
+import { useUpdateProfileImageMutation } from "@/app/kakao/_hooks/_mutations/useUpdateProfile"
 import { useUpdateNicknameMutation } from "@/app/kakao/_hooks/_mutations/useUpdateNickname"
 import { useEffect } from "react"
-import NickNameForm from "../../_components/NickNameForm"
+import NickNameForm from "@/app/kakao/_components/NickNameForm"
 import Step from "@/_common/_hooks/useFunnel/_component/Step"
-import AvatarForm from "../../_components/AvatarForm"
+import AvatarForm from "@/app/kakao/_components/AvatarForm"
 
 const KakaoLoginWithSocialId = ({
   params
@@ -23,6 +24,7 @@ const KakaoLoginWithSocialId = ({
   const router = useRouter()
   const { mutate } = useGetCSRFToken()
   const { mutate: updateNickname } = useUpdateNicknameMutation()
+  const { mutate: updateProfileImage } = useUpdateProfileImageMutation()
   const { toast } = useToast()
 
   useEffect(() => {
@@ -42,8 +44,7 @@ const KakaoLoginWithSocialId = ({
 
           router.push("/meeting")
         },
-        onError: (e) => {
-          console.log(e)
+        onError: () => {
           toast({
             type: "background",
             title: "로그인에 실패하였습니다!",
@@ -70,10 +71,10 @@ const KakaoLoginWithSocialId = ({
                     onSuccess: () => {
                       setStep("profileAvatar")
                     },
-                    onError: () => {
+                    onError: (e) => {
                       toast({
                         duration: 1000,
-                        title: "사비스를 이용할 수 없어요!",
+                        title: e.message,
                         type: "background"
                       })
                     }
@@ -83,7 +84,22 @@ const KakaoLoginWithSocialId = ({
             />
           </Step>
           <Step name="profileAvatar">
-            <AvatarForm />
+            <AvatarForm
+              onSubmit={(profileimage) => {
+                updateProfileImage(profileimage, {
+                  onSuccess: () => {
+                    setStep("verify-user-info")
+                  },
+                  onError: (err) => {
+                    toast({
+                      duration: 1000,
+                      title: "사비스를 이용할 수 없어요!",
+                      type: "background"
+                    })
+                  }
+                })
+              }}
+            />
           </Step>
           <Step name="verify-user-info">
             <SuccessLogin onLoginSuccess={handleLoginSuccess} />

--- a/src/app/kakao/login/[socialid]/page.tsx
+++ b/src/app/kakao/login/[socialid]/page.tsx
@@ -3,27 +3,28 @@
 import { useFunnel } from "@/_common/_hooks/useFunnel"
 import { useKakaoOAuthMutation } from "@/app/kakao/_hooks/_mutations/useKakaoMutation"
 
-import NickNameForm from "@/app/kakao/_components/NickNameForm"
-import Step from "@/_common/_hooks/useFunnel/_component/Step"
 import { UserSignInProvider } from "@/app/kakao/_context/signinContext"
 import { SuccessLogin } from "@/app/kakao/_components/SuccessLogin"
 import { useToast } from "@/_common/_hooks/useToast"
 import { useRouter } from "next/navigation"
 import { useGetCSRFToken } from "@/app/kakao/_api/auth/csrf"
-import { toast } from "@/_common/_hooks/useToast"
-import AvatarForm from "@/app/kakao/_components/AvatarForm"
+import { useUpdateNicknameMutation } from "@/app/kakao/_hooks/_mutations/useUpdateNickname"
 import { useEffect } from "react"
+import NickNameForm from "../../_components/NickNameForm"
+import Step from "@/_common/_hooks/useFunnel/_component/Step"
+import AvatarForm from "../../_components/AvatarForm"
 
 const KakaoLoginWithSocialId = ({
   params
 }: {
   params: { socialid: string }
 }) => {
-  const { mutate: getCSRF } = useGetCSRFToken()
   const mutation = useKakaoOAuthMutation()
   const router = useRouter()
   const { mutate } = useGetCSRFToken()
+  const { mutate: updateNickname } = useUpdateNicknameMutation()
   const { toast } = useToast()
+
   useEffect(() => {
     mutate()
   }, [])
@@ -33,15 +34,16 @@ const KakaoLoginWithSocialId = ({
       { code: params.socialid },
       {
         onSuccess: () => {
-          getCSRF()
           toast({
             title: "로그인 성공",
             description: "로그인에 성공하셨어요"
           })
+          mutate()
 
           router.push("/meeting")
         },
-        onError: () => {
+        onError: (e) => {
+          console.log(e)
           toast({
             type: "background",
             title: "로그인에 실패하였습니다!",
@@ -58,7 +60,35 @@ const KakaoLoginWithSocialId = ({
   return (
     <UserSignInProvider>
       <div>
-        <SuccessLogin onLoginSuccess={handleLoginSuccess} />
+        <Funnel>
+          <Step name="nickname">
+            <NickNameForm
+              onSubmit={(nickname: string) => {
+                updateNickname(
+                  { nickname },
+                  {
+                    onSuccess: () => {
+                      setStep("profileAvatar")
+                    },
+                    onError: () => {
+                      toast({
+                        duration: 1000,
+                        title: "사비스를 이용할 수 없어요!",
+                        type: "background"
+                      })
+                    }
+                  }
+                )
+              }}
+            />
+          </Step>
+          <Step name="profileAvatar">
+            <AvatarForm />
+          </Step>
+          <Step name="verify-user-info">
+            <SuccessLogin onLoginSuccess={handleLoginSuccess} />
+          </Step>
+        </Funnel>
       </div>
     </UserSignInProvider>
   )

--- a/src/app/mypage/_components/MyPageClient.tsx
+++ b/src/app/mypage/_components/MyPageClient.tsx
@@ -16,9 +16,9 @@ const MyPageClient = () => {
     <div>
       <MyPageTopBar />
       <ProfileSection
-        profileImg={userInform.profileImg}
-        nickName={userInform.nickName}
-        profileIntroduce=""
+        profileImg={userInform.profile_image_url}
+        nickName={userInform.display_name}
+        profileIntroduce={userInform.description}
       />
       <MeetingSummarySection
         participatedMeetingList={userInform.participatedMeetingList ?? []}

--- a/src/app/mypage/types.ts
+++ b/src/app/mypage/types.ts
@@ -1,7 +1,10 @@
 export interface UserInformTypes {
-  profileImg: string
-  nickName: string
-  userId: string
-  profileIntroduce: string
+  id: number
+  display_name: string
+  social_id: string
+  social_type: string
+  profile_image_url: string
+  description: string
+  phone_number: string
   participatedMeetingList: string[]
 }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,5 +1,6 @@
 import returnFetch, { FetchArgs } from "return-fetch"
 import CustomError from "@/lib/CustomError"
+import { postCSRF } from "@/app/kakao/_api/auth/csrf"
 
 const createHTTP = () => {
   return async <T>(
@@ -7,7 +8,6 @@ const createHTTP = () => {
     init?: RequestInit
   ): Promise<{ data: T; status?: number }> => {
     return returnFetch({
-      baseUrl: "",
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json"
@@ -21,7 +21,9 @@ const createHTTP = () => {
           return config
         },
         response: async (response: Response) => {
-          const responseBody = await response.json()
+          let responseBody
+          const text = await response.text()
+          responseBody = text ? JSON.parse(text) : { data: "success" }
 
           if (response.status >= 400) {
             throw new CustomError(


### PR DESCRIPTION
#129 

내 정보 조회부분, 프로필 입력, 사진 업로드 API를 붙이는 작업을 완료했어요.
프로필 입력과 사진 업로드는 퍼널의 흐름을 가져가고 서버와의 통신 중 오류가 있다면 토스트를 띄우게 됩니다.

추가로 API호출시 앞에 /api/v1 <-요걸 붙이면 됩니다.

![image](https://github.com/user-attachments/assets/a6e547c1-4be0-4565-9d30-c25254e1f129)
해당 오류는 200으로 응답이 왔을 때 Response Body가 아예 안들어와서 발생했던 문제였어요.!!!

따라서 아래처럼 바로 response.json을 호출하는 게 아니라 response.text로 한번 변환 후에 json파싱을 하게 하였습니다.

```ts
let responseBody
const text = await response.text()
responseBody = text ? JSON.parse(text) : { data: "success" }
```

### 궁금한점

서버에서 400번대 오류가 났을 때, Response Body로 message가 들어오는데, 요 값을 토스트에 띄우고 싶은데 어떻게 하나요..!
