### PR TITLE
feat: 아래로 스크롤 기능 추가

### DIFF
--- a/src/_common/_components/ScrollDown/index.tsx
+++ b/src/_common/_components/ScrollDown/index.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon } from "lucide-react"
+import React, { forwardRef, useEffect, useRef } from "react"
+
+interface ScrollDownProps {
+  children: React.ReactNode
+  className?: string
+}
+
+const ScrollDown = forwardRef<HTMLDivElement, ScrollDownProps>(
+  ({ children, className }, ref) => {
+    const [clicked, setClicked] = React.useState(false)
+    const bottomRef = ref as React.MutableRefObject<HTMLDivElement | null>
+
+    useEffect(() => {
+      if (clicked) {
+        setClicked(false)
+        if (bottomRef && bottomRef.current) {
+          bottomRef.current.scrollIntoView({ behavior: "smooth" })
+        }
+      }
+    }, [clicked, bottomRef])
+
+    return (
+      <div className="relative">
+        {children}
+        <ChevronDownIcon
+          onClick={() => setClicked(true)}
+          className={cn(
+            "fixed bottom-5 right-5 rounded-full shadow-lg w-8 h-8 bg-slate-200",
+            className
+          )}
+        />
+      </div>
+    )
+  }
+)
+
+ScrollDown.displayName = "ScrollDown"
+
+export default ScrollDown

--- a/src/_common/_components/ScrollDown/index.tsx
+++ b/src/_common/_components/ScrollDown/index.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/utils"
 import { ChevronDownIcon } from "lucide-react"
 import React, { forwardRef, useEffect, useRef } from "react"
 
-interface ScrollDownProps {
+export interface ScrollDownProps {
   children: React.ReactNode
   className?: string
 }

--- a/src/_common/_components/ScrollDown/index.tsx
+++ b/src/_common/_components/ScrollDown/index.tsx
@@ -5,10 +5,11 @@ import React, { forwardRef, useEffect, useRef } from "react"
 export interface ScrollDownProps {
   children: React.ReactNode
   className?: string
+  props?: React.HTMLAttributes<SVGSVGElement>
 }
 
 const ScrollDown = forwardRef<HTMLDivElement, ScrollDownProps>(
-  ({ children, className }, ref) => {
+  ({ children, className, ...props }, ref) => {
     const [clicked, setClicked] = React.useState(false)
     const bottomRef = ref as React.MutableRefObject<HTMLDivElement | null>
 
@@ -25,6 +26,7 @@ const ScrollDown = forwardRef<HTMLDivElement, ScrollDownProps>(
       <div className="relative">
         {children}
         <ChevronDownIcon
+          {...props}
           onClick={() => setClicked(true)}
           className={cn(
             "fixed bottom-5 right-5 rounded-full shadow-lg w-8 h-8 bg-slate-200",

--- a/src/app/chat/[chatId]/_components/MyMessageGroup.tsx
+++ b/src/app/chat/[chatId]/_components/MyMessageGroup.tsx
@@ -9,7 +9,7 @@ export interface MyMessageGroupProps {
 }
 const MyMessageGroup = ({ messages, userInfo, role }: MyMessageGroupProps) => {
   return (
-    <div className="flex flex-col gap-4 w-full pb-4">
+    <div className="flex flex-col gap-4 w-full pb-4 pl-4">
       <MessageHeader
         username={userInfo.username}
         avatarSrc={userInfo.avatarSrc}

--- a/src/app/chat/[chatId]/_components/OtherMessageGroup.tsx
+++ b/src/app/chat/[chatId]/_components/OtherMessageGroup.tsx
@@ -14,7 +14,7 @@ const OtherMessageGroup = ({
   messages
 }: OtherMessageGroupProps) => {
   return (
-    <div className="flex flex-col gap-4 pb-4">
+    <div className="flex flex-col gap-4 pb-4 pr-4">
       <MessageHeader
         username={username}
         avatarSrc={avatarSrc}

--- a/src/app/chat/[chatId]/_hooks/_test/useChatScroll.spec.tsx
+++ b/src/app/chat/[chatId]/_hooks/_test/useChatScroll.spec.tsx
@@ -1,0 +1,65 @@
+import useChatScroll from "@/app/chat/[chatId]/_hooks/useChatScroll"
+import { describe, test, jest, expect } from "@jest/globals"
+import { render, fireEvent, waitFor, act } from "@testing-library/react"
+
+const callbackSpy = jest.fn()
+// @ts-ignore
+global.IntersectionObserver = jest.fn((callback, options) => {
+  callbackSpy.mockImplementation(callback as any)
+  return {
+    observe: jest.fn(),
+    disconnect: jest.fn(),
+    unobserve: jest.fn(),
+    callback
+  }
+})
+
+global.HTMLElement.prototype.scrollIntoView = jest.fn()
+
+interface Item {
+  id: string
+  text: string
+}
+
+const MockComponentList = ({ data }: { data: Item[] }) => {
+  const { BottomDiv, ScrollDown } = useChatScroll([data])
+
+  return (
+    <div>
+      <ScrollDown aria-label="scroll-down-button">
+        {data.map((item) => (
+          <div
+            className="h-[30%]"
+            key={item.id}>
+            {item.text}
+          </div>
+        ))}
+      </ScrollDown>
+      <BottomDiv aria-label="bottom-div" />
+    </div>
+  )
+}
+
+describe("useChatScroll", () => {
+  test("ScrollDown 버튼 클릭 시, 화면이 아래로 스크롤 되어야 한다.", async () => {
+    const data = new Array(100).fill(0).map((_, index) => ({
+      id: index.toString(),
+      text: index.toString()
+    }))
+
+    const { getByLabelText } = render(<MockComponentList data={data} />)
+    act(() => {
+      callbackSpy([{ isIntersecting: false }])
+    })
+
+    const bottomDiv = getByLabelText("bottom-div")
+
+    await waitFor(() => {
+      const scrollDownButton = getByLabelText("scroll-down-button")
+      fireEvent.click(scrollDownButton)
+    })
+
+    // 아래로 스크롤이 호출 됐는지 확인
+    expect(bottomDiv.scrollIntoView).toHaveBeenCalled()
+  })
+})

--- a/src/app/chat/[chatId]/_hooks/useChatScroll.tsx
+++ b/src/app/chat/[chatId]/_hooks/useChatScroll.tsx
@@ -21,11 +21,17 @@ const useChatScroll = (dependencies: unknown[]) => {
   }, [bottomRef, ...dependencies])
 
   const ScrollDownComponent = ({ children, ...props }: ScrollDownProps) => (
-    <ScrollDown
-      {...props}
-      ref={bottomRef}>
-      {children}
-    </ScrollDown>
+    <>
+      {auto ? (
+        children
+      ) : (
+        <ScrollDown
+          {...props}
+          ref={bottomRef}>
+          {children}
+        </ScrollDown>
+      )}
+    </>
   )
 
   const BottomDiv = (props: React.HTMLAttributes<HTMLDivElement>) => (

--- a/src/app/chat/[chatId]/_hooks/useChatScroll.tsx
+++ b/src/app/chat/[chatId]/_hooks/useChatScroll.tsx
@@ -1,5 +1,6 @@
+import ScrollDown, { ScrollDownProps } from "@/_common/_components/ScrollDown"
 import useIntersecting from "@/_common/_hooks/useIntersecting"
-import { useEffect, useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 
 const useChatScroll = (dependencies: unknown[]) => {
   const [auto, setAuto] = useState(true)
@@ -19,7 +20,22 @@ const useChatScroll = (dependencies: unknown[]) => {
     }
   }, [bottomRef, ...dependencies])
 
-  return { bottomRef }
+  const ScrollDownComponent = ({ children, ...props }: ScrollDownProps) => (
+    <ScrollDown
+      {...props}
+      ref={bottomRef}>
+      {children}
+    </ScrollDown>
+  )
+
+  const BottomDiv = (props: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+      {...props}
+      ref={bottomRef}
+    />
+  )
+
+  return { BottomDiv, ScrollDown: ScrollDownComponent }
 }
 
 export default useChatScroll

--- a/src/app/chat/[chatId]/page.tsx
+++ b/src/app/chat/[chatId]/page.tsx
@@ -31,7 +31,7 @@ const ChatPage = ({ params }: ChatPageProps) => {
   const { messages, sendMessage } = useStomp(params.chatId)
   const { data } = useFetchChatHistory(params.chatId)
 
-  const { bottomRef } = useChatScroll([chatHistory])
+  const { BottomDiv, ScrollDown } = useChatScroll([chatHistory])
 
   const onSubmit = (data: { message: string }) => {
     sendMessage({
@@ -67,31 +67,33 @@ const ChatPage = ({ params }: ChatPageProps) => {
     <>
       <ChatPageTopbar title={data.title ?? "title"} />
       <div>
-        <ul aria-label="메세지 리스트">
-          {chatHistory.map((messageGroup) => (
-            <li
-              aria-label="메세지 그룹"
-              key={messageGroup.id}>
-              {messageGroup.me ? (
-                <MyMessageGroup
-                  role={messageGroup.role}
-                  messages={messageGroup.messages}
-                  userInfo={messageGroup.userInfo}
-                />
-              ) : (
-                <OtherMessageGroup
-                  role={messageGroup.role}
-                  messages={messageGroup.messages}
-                  userInfo={messageGroup.userInfo}
-                />
-              )}
-            </li>
-          ))}
-          <div
-            className="z-50"
-            ref={bottomRef}></div>
-          <div className="h-28"></div>
-        </ul>
+        <ScrollDown className=" bottom-32">
+          <ul
+            aria-label="메세지 리스트"
+            className="relative">
+            {chatHistory.map((messageGroup) => (
+              <li
+                aria-label="메세지 그룹"
+                key={messageGroup.id}>
+                {messageGroup.me ? (
+                  <MyMessageGroup
+                    role={messageGroup.role}
+                    messages={messageGroup.messages}
+                    userInfo={messageGroup.userInfo}
+                  />
+                ) : (
+                  <OtherMessageGroup
+                    role={messageGroup.role}
+                    messages={messageGroup.messages}
+                    userInfo={messageGroup.userInfo}
+                  />
+                )}
+              </li>
+            ))}
+            <BottomDiv />
+            <div className="h-28"></div>
+          </ul>
+        </ScrollDown>
         <form
           onSubmit={handleSubmit(onSubmit)}
           className="flex fixed bottom-2 bg-white px-2 py-2 gap-2 pb-16 w-full">

--- a/src/app/chat/[chatId]/page.tsx
+++ b/src/app/chat/[chatId]/page.tsx
@@ -68,9 +68,7 @@ const ChatPage = ({ params }: ChatPageProps) => {
       <ChatPageTopbar title={data.title ?? "title"} />
       <div>
         <ScrollDown className=" bottom-32">
-          <ul
-            aria-label="메세지 리스트"
-            className="relative">
+          <ul aria-label="메세지 리스트">
             {chatHistory.map((messageGroup) => (
               <li
                 aria-label="메세지 그룹"


### PR DESCRIPTION
close #132 

# ScrollDown 컴포넌트 
사용자가 이전 채팅 기록을 볼 때, 아래로 스크롤 버튼을 통해 수동으로 스크롤 하는 수고를 덜어주는 컴포넌트를 만들었습니다.
ScrollDown 컴포넌트를 적용하고 싶은 컴포넌트에 감싸면, 그 컴포넌트를 기준으로 오른쪽 아래에 위치를 잡습니다.
props 로 ref 를 받아 클릭 되면 ref 로 이동합니다.
```ts
<ScrollDown
  ref={bottomRef}
>
  {children}
</ScrollDown>
```

# useChatScroll 에 적용
useChatScroll 이 받는 ref 를 ScrollDown 컴포넌트에 제공한 컴포넌트를 반환하여, 불필요한 props 를 추상화 했습니다.

# 사용 예시
https://github.com/user-attachments/assets/b5faa74a-1716-46d6-a4e2-388210c490ad